### PR TITLE
Add ClawHub-ready OpenClaw skill package

### DIFF
--- a/clawhub/tutti/CHANGELOG.md
+++ b/clawhub/tutti/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 1.0.0 (2026-03-14)
+
+Initial release.
+
+- 16 actions covering the full Tutti agent lifecycle
+- JSON envelope on all outputs for reliable machine parsing
+- Direct state file reads for status (no output parsing)
+- Workflow discovery, planning (dry-run), and execution
+- Handoff packet generation, application, and listing
+- Permission policy checks
+- Configurable `tt` binary path via `--tt-bin` flag or `TUTTI_BIN` env var

--- a/clawhub/tutti/SKILL.md
+++ b/clawhub/tutti/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: tutti
+description: Orchestrate multiple AI coding agents (Claude Code, Codex, Aider) from a single config — launch teams, run workflows, track capacity, and manage handoffs.
+version: 1.0.0
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - tt
+        - tmux
+        - python3
+    emoji: "\U0001F3B6"
+    homepage: https://github.com/nutthouse/tutti
+---
+
+# Tutti — Multi-Agent Orchestration
+
+Orchestrate a team of AI coding agents from a declarative `tutti.toml` config. Launch agents in isolated git worktrees, run verification workflows, track token usage, and manage context handoffs — all through a single CLI.
+
+## When to use this skill
+
+Use when the user asks you to:
+- Launch, monitor, or stop a team of AI coding agents
+- Run or verify automated workflows across agents
+- Check agent status, health, or capacity usage
+- Generate or apply context handoff packets
+- Coordinate multi-agent development workflows
+
+## Prerequisites
+
+1. `tt` binary installed and on PATH (install from https://github.com/nutthouse/tutti)
+2. `tmux` installed
+3. `python3` available
+4. A `tutti.toml` config file in the workspace root
+
+Always run preflight checks before starting a workflow:
+```bash
+python3 tutti_openclaw.py doctor_check
+```
+
+## Actions
+
+All actions go through the wrapper script. Every action returns a consistent JSON envelope:
+
+```json
+{
+  "ok": true,
+  "action": "action_name",
+  "command": ["tt", "..."],
+  "exit_code": 0,
+  "data": {},
+  "stdout": "",
+  "stderr": ""
+}
+```
+
+### Lifecycle
+
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `doctor_check` | `python3 tutti_openclaw.py doctor_check` | Preflight: verify tools, config, and environment |
+| `launch_team` | `python3 tutti_openclaw.py launch_team` | Launch all agents defined in tutti.toml |
+| `launch_agent` | `python3 tutti_openclaw.py launch_agent <name>` | Launch a single agent |
+| `team_status` | `python3 tutti_openclaw.py team_status` | Read agent states from .tutti/state/ |
+| `agent_output` | `python3 tutti_openclaw.py agent_output <name> --lines 50` | Peek at an agent's terminal output |
+| `stop_agent` | `python3 tutti_openclaw.py stop_agent <name>` | Stop a single agent |
+| `stop_team` | `python3 tutti_openclaw.py stop_team` | Stop all agents |
+
+### Workflows
+
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `list_workflows` | `python3 tutti_openclaw.py list_workflows` | Discover available workflows |
+| `plan_workflow` | `python3 tutti_openclaw.py plan_workflow <name> [--strict]` | Dry-run a workflow |
+| `run_workflow` | `python3 tutti_openclaw.py run_workflow <name> [--agent <a>] [--strict]` | Execute a workflow |
+| `verify_team` | `python3 tutti_openclaw.py verify_team [--workflow <w>] [--strict]` | Run verification workflow |
+| `read_verify_status` | `python3 tutti_openclaw.py read_verify_status` | Read last verification result |
+
+### Handoffs
+
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `generate_handoff` | `python3 tutti_openclaw.py generate_handoff <agent> [--reason <r>]` | Capture agent context to a packet |
+| `apply_handoff` | `python3 tutti_openclaw.py apply_handoff <agent> [--packet <path>]` | Inject a handoff packet into an agent |
+| `list_handoffs` | `python3 tutti_openclaw.py list_handoffs [--agent <a>] [--limit 20]` | List available handoff packets |
+
+### Permissions
+
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `permissions_check` | `python3 tutti_openclaw.py permissions_check <cmd...>` | Check if a command is allowed by policy |
+
+## Execution pattern
+
+Follow this sequence for orchestrating a workspace:
+
+1. **Preflight** — `doctor_check`. Stop and report if non-zero.
+2. **Launch** — `launch_team` or `launch_agent <name>`.
+3. **Monitor** — `team_status` and `agent_output <name>` to observe progress.
+4. **Workflow** — `list_workflows` to discover, then `run_workflow <name>`.
+5. **Verify** — `verify_team --strict` for gate-style quality checks.
+6. **Handoff** — `generate_handoff <agent>` when context is high, `apply_handoff <agent>` to resume.
+7. **Stop** — `stop_team` or `stop_agent <name>` when done.
+
+## Failure handling
+
+- **Non-zero exit**: Surface the `action`, `command`, and `stderr` from the JSON envelope. Do not retry blindly.
+- **Verify warnings (non-strict)**: Report as warning. Include data from `read_verify_status`.
+- **Missing state files**: Treat as transient — retry up to 3 times with short delays. If still missing, the workspace may not have been launched.
+- **Auth failures**: If `stderr` contains auth errors, stop and escalate to the user. Do not retry auth failures.
+
+## Configuration override
+
+If `tt` is not on PATH or you need a specific version:
+
+```bash
+python3 tutti_openclaw.py --tt-bin /path/to/tt doctor_check
+# or via environment variable
+TUTTI_BIN=/path/to/tt python3 tutti_openclaw.py doctor_check
+```
+
+## Rules
+
+- Always run `doctor_check` before any launch or workflow operation.
+- Never retry auth failures — escalate to the user immediately.
+- Prefer `team_status` (reads state files directly) over `agent_output` for status checks.
+- Use `--strict` flag on `verify_team` and `run_workflow` when results gate further actions.
+- Use `--json` output from `tt` commands when you need structured data (the wrapper handles this automatically).
+- Do not parse `stdout` text output — always use the `data` field from the JSON envelope.

--- a/clawhub/tutti/action-contract.json
+++ b/clawhub/tutti/action-contract.json
@@ -1,0 +1,102 @@
+{
+  "name": "tutti-openclaw",
+  "version": "1.0.0",
+  "description": "Action contract for using Tutti from OpenClaw via integrations/openclaw/tutti_openclaw.py",
+  "entrypoint": "integrations/openclaw/tutti_openclaw.py",
+  "global_args": {
+    "--tt-bin": "Override the Tutti CLI command/prefix (defaults to `tt`, or TUTTI_BIN env var)"
+  },
+  "output_envelope": {
+    "ok": "boolean",
+    "action": "string",
+    "command": "array<string>|null",
+    "exit_code": "number",
+    "data": "any",
+    "stdout": "string",
+    "stderr": "string",
+    "parse_error": "string|null",
+    "note": "string|null"
+  },
+  "actions": [
+    {
+      "name": "doctor_check",
+      "args": [],
+      "description": "Run tt doctor --json"
+    },
+    {
+      "name": "permissions_check",
+      "args": ["<command...>"],
+      "description": "Run tt permissions check <command...> --json"
+    },
+    {
+      "name": "launch_team",
+      "args": [],
+      "description": "Run tt up"
+    },
+    {
+      "name": "launch_agent",
+      "args": ["<agent>"],
+      "description": "Run tt up <agent>"
+    },
+    {
+      "name": "list_workflows",
+      "args": [],
+      "description": "Run tt run --list --json"
+    },
+    {
+      "name": "plan_workflow",
+      "args": ["<workflow>", "[--agent <agent>]", "[--strict]"],
+      "description": "Run tt run <workflow> --dry-run --json"
+    },
+    {
+      "name": "run_workflow",
+      "args": ["<workflow>", "[--agent <agent>]", "[--strict]"],
+      "description": "Run tt run <workflow> --json"
+    },
+    {
+      "name": "verify_team",
+      "args": ["[--workflow <name>]", "[--agent <agent>]", "[--strict]"],
+      "description": "Run tt verify --json"
+    },
+    {
+      "name": "read_verify_status",
+      "args": [],
+      "description": "Run tt verify --last --json"
+    },
+    {
+      "name": "generate_handoff",
+      "args": ["<agent>", "[--reason <reason>]", "[--ctx <pct>]"],
+      "description": "Run tt handoff generate <agent> --json"
+    },
+    {
+      "name": "apply_handoff",
+      "args": ["<agent>", "[--packet <path>]"],
+      "description": "Run tt handoff apply <agent>"
+    },
+    {
+      "name": "list_handoffs",
+      "args": ["[--agent <agent>]", "[--limit <n>]"],
+      "description": "Run tt handoff list --json"
+    },
+    {
+      "name": "team_status",
+      "args": [],
+      "description": "Read .tutti/state/*.json and return agent status payload"
+    },
+    {
+      "name": "agent_output",
+      "args": ["<agent>", "[--lines <n>]"],
+      "description": "Run tt peek <agent> --lines <n>"
+    },
+    {
+      "name": "stop_agent",
+      "args": ["<agent>"],
+      "description": "Run tt down <agent>"
+    },
+    {
+      "name": "stop_team",
+      "args": [],
+      "description": "Run tt down"
+    }
+  ]
+}

--- a/clawhub/tutti/tutti_openclaw.py
+++ b/clawhub/tutti/tutti_openclaw.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+OpenClaw <-> Tutti action wrapper.
+
+This script provides a stable JSON envelope around Tutti commands so an external
+agent can call one binary/script entrypoint and always get machine-readable
+results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CommandResult:
+    ok: bool
+    action: str
+    command: list[str] | None
+    exit_code: int
+    data: Any
+    stdout: str
+    stderr: str
+    parse_error: str | None = None
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "action": self.action,
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "data": self.data,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+        if self.parse_error:
+            out["parse_error"] = self.parse_error
+        if self.note:
+            out["note"] = self.note
+        return out
+
+
+def _run_tt(action: str, tt_bin: list[str], args: list[str], expect_json: bool) -> CommandResult:
+    cmd = [*tt_bin, *args]
+    try:
+        proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    except FileNotFoundError:
+        return CommandResult(
+            ok=False,
+            action=action,
+            command=cmd,
+            exit_code=127,
+            data=None,
+            stdout="",
+            stderr="tt command not found on PATH",
+        )
+
+    data: Any = None
+    parse_error: str | None = None
+    if expect_json:
+        payload = proc.stdout.strip()
+        if payload:
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                parse_error = f"failed to parse command JSON output: {exc}"
+
+    ok = proc.returncode == 0 and (parse_error is None or not expect_json)
+    return CommandResult(
+        ok=ok,
+        action=action,
+        command=cmd,
+        exit_code=proc.returncode,
+        data=data,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        parse_error=parse_error,
+    )
+
+
+def _team_status(action: str) -> CommandResult:
+    state_dir = Path(".tutti") / "state"
+    if not state_dir.exists():
+        return CommandResult(
+            ok=True,
+            action=action,
+            command=None,
+            exit_code=0,
+            data={"agents": [], "count": 0, "state_dir": str(state_dir), "exists": False},
+            stdout="",
+            stderr="",
+            note="state directory not found",
+        )
+
+    agents: list[dict[str, Any]] = []
+    parse_errors: list[str] = []
+    for path in sorted(state_dir.glob("*.json")):
+        # ignore non-agent state files
+        if path.name in {"verify-last.json"}:
+            continue
+        try:
+            payload = json.loads(path.read_text())
+        except Exception as exc:  # pylint: disable=broad-except
+            parse_errors.append(f"{path.name}: {exc}")
+            continue
+        if not isinstance(payload, dict):
+            continue
+        required = {"name", "runtime", "session_name", "status", "started_at"}
+        if required.issubset(payload.keys()):
+            agents.append(payload)
+
+    return CommandResult(
+        ok=True,
+        action=action,
+        command=None,
+        exit_code=0,
+        data={
+            "agents": agents,
+            "count": len(agents),
+            "state_dir": str(state_dir),
+            "exists": True,
+            "parse_errors": parse_errors,
+        },
+        stdout="",
+        stderr="",
+    )
+
+
+def _agent_output(action: str, tt_bin: list[str], agent: str, lines: int) -> CommandResult:
+    result = _run_tt(action, tt_bin, ["peek", agent, "--lines", str(lines)], expect_json=False)
+    result.data = {
+        "agent": agent,
+        "lines": lines,
+        "output_lines": result.stdout.splitlines(),
+    }
+    return result
+
+
+def _print_and_exit(result: CommandResult) -> None:
+    print(json.dumps(result.to_dict(), indent=2))
+    raise SystemExit(result.exit_code if result.exit_code >= 0 else 1)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tutti_openclaw.py",
+        description="OpenClaw wrapper for Tutti actions",
+    )
+    parser.add_argument(
+        "--tt-bin",
+        default=os.environ.get("TUTTI_BIN", "tt"),
+        help="Tutti CLI command/prefix to execute (default: tt, or TUTTI_BIN env var)",
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    sub.add_parser("doctor_check", help="Run tt doctor --json")
+    p_perm = sub.add_parser("permissions_check", help="Run tt permissions check ... --json")
+    p_perm.add_argument("command", nargs=argparse.REMAINDER, help="Command to evaluate")
+
+    sub.add_parser("launch_team", help="Run tt up")
+    p_launch = sub.add_parser("launch_agent", help="Run tt up <agent>")
+    p_launch.add_argument("agent")
+
+    sub.add_parser("list_workflows", help="Run tt run --list --json")
+    p_plan = sub.add_parser("plan_workflow", help="Run tt run <workflow> --dry-run --json")
+    p_plan.add_argument("workflow")
+    p_plan.add_argument("--agent")
+    p_plan.add_argument("--strict", action="store_true")
+
+    p_run = sub.add_parser("run_workflow", help="Run tt run <workflow> --json")
+    p_run.add_argument("workflow")
+    p_run.add_argument("--agent")
+    p_run.add_argument("--strict", action="store_true")
+
+    p_verify = sub.add_parser("verify_team", help="Run tt verify --json")
+    p_verify.add_argument("--workflow")
+    p_verify.add_argument("--agent")
+    p_verify.add_argument("--strict", action="store_true")
+
+    sub.add_parser("read_verify_status", help="Run tt verify --last --json")
+    p_gen_handoff = sub.add_parser("generate_handoff", help="Run tt handoff generate <agent> --json")
+    p_gen_handoff.add_argument("agent")
+    p_gen_handoff.add_argument("--reason")
+    p_gen_handoff.add_argument("--ctx", type=int)
+    p_apply_handoff = sub.add_parser("apply_handoff", help="Run tt handoff apply <agent>")
+    p_apply_handoff.add_argument("agent")
+    p_apply_handoff.add_argument("--packet")
+    p_list_handoffs = sub.add_parser("list_handoffs", help="Run tt handoff list --json")
+    p_list_handoffs.add_argument("--agent")
+    p_list_handoffs.add_argument("--limit", type=int, default=20)
+    sub.add_parser("team_status", help="Read .tutti/state/*.json")
+
+    p_output = sub.add_parser("agent_output", help="Run tt peek <agent> --lines N")
+    p_output.add_argument("agent")
+    p_output.add_argument("--lines", type=int, default=100)
+
+    p_stop = sub.add_parser("stop_agent", help="Run tt down <agent>")
+    p_stop.add_argument("agent")
+    sub.add_parser("stop_team", help="Run tt down")
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    action = args.action
+    tt_bin = shlex.split(args.tt_bin)
+    if not tt_bin:
+        result = CommandResult(
+            ok=False,
+            action=action,
+            command=None,
+            exit_code=2,
+            data=None,
+            stdout="",
+            stderr="--tt-bin resolved to empty command",
+        )
+        _print_and_exit(result)
+
+    if action == "doctor_check":
+        _print_and_exit(_run_tt(action, tt_bin, ["doctor", "--json"], expect_json=True))
+
+    if action == "permissions_check":
+        if not args.command:
+            result = CommandResult(
+                ok=False,
+                action=action,
+                command=None,
+                exit_code=2,
+                data=None,
+                stdout="",
+                stderr="permissions_check requires a command payload",
+            )
+            _print_and_exit(result)
+        _print_and_exit(
+            _run_tt(
+                action,
+                tt_bin,
+                ["permissions", "check", *args.command, "--json"],
+                expect_json=True,
+            )
+        )
+
+    if action == "launch_team":
+        _print_and_exit(_run_tt(action, tt_bin, ["up"], expect_json=False))
+    if action == "launch_agent":
+        _print_and_exit(_run_tt(action, tt_bin, ["up", args.agent], expect_json=False))
+    if action == "list_workflows":
+        _print_and_exit(_run_tt(action, tt_bin, ["run", "--list", "--json"], expect_json=True))
+    if action == "plan_workflow":
+        cmd = ["run", args.workflow, "--dry-run", "--json"]
+        if args.agent:
+            cmd.extend(["--agent", args.agent])
+        if args.strict:
+            cmd.append("--strict")
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=True))
+    if action == "run_workflow":
+        cmd = ["run", args.workflow, "--json"]
+        if args.agent:
+            cmd.extend(["--agent", args.agent])
+        if args.strict:
+            cmd.append("--strict")
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=True))
+    if action == "verify_team":
+        cmd = ["verify", "--json"]
+        if args.workflow:
+            cmd.extend(["--workflow", args.workflow])
+        if args.agent:
+            cmd.extend(["--agent", args.agent])
+        if args.strict:
+            cmd.append("--strict")
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=True))
+    if action == "read_verify_status":
+        _print_and_exit(
+            _run_tt(action, tt_bin, ["verify", "--last", "--json"], expect_json=True)
+        )
+    if action == "generate_handoff":
+        cmd = ["handoff", "generate", args.agent, "--json"]
+        if args.reason:
+            cmd.extend(["--reason", args.reason])
+        if args.ctx is not None:
+            cmd.extend(["--ctx", str(args.ctx)])
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=True))
+    if action == "apply_handoff":
+        cmd = ["handoff", "apply", args.agent]
+        if args.packet:
+            cmd.extend(["--packet", args.packet])
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=False))
+    if action == "list_handoffs":
+        cmd = ["handoff", "list", "--json", "--limit", str(args.limit)]
+        if args.agent:
+            cmd.extend(["--agent", args.agent])
+        _print_and_exit(_run_tt(action, tt_bin, cmd, expect_json=True))
+    if action == "team_status":
+        _print_and_exit(_team_status(action))
+    if action == "agent_output":
+        _print_and_exit(_agent_output(action, tt_bin, args.agent, args.lines))
+    if action == "stop_agent":
+        _print_and_exit(_run_tt(action, tt_bin, ["down", args.agent], expect_json=False))
+    if action == "stop_team":
+        _print_and_exit(_run_tt(action, tt_bin, ["down"], expect_json=False))
+
+    result = CommandResult(
+        ok=False,
+        action=action,
+        command=None,
+        exit_code=2,
+        data=None,
+        stdout="",
+        stderr=f"unsupported action: {action}",
+    )
+    _print_and_exit(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Packages the existing OpenClaw integration into ClawHub's expected skill format
- `SKILL.md` with proper YAML frontmatter (`requires.bins`, emoji, homepage)
- Full action reference tables, execution pattern, and failure handling docs
- Python wrapper, action contract, and changelog included alongside

Ready to publish via `clawhub publish clawhub/tutti/ --slug tutti`

## Test plan
- [ ] Verify `SKILL.md` frontmatter parses correctly with ClawHub validator
- [ ] Run `python3 clawhub/tutti/tutti_openclaw.py --help` confirms all 16 actions
- [ ] Publish to ClawHub staging or dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)