### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/nutthouse/tutti/security/code-scanning/1](https://github.com/nutthouse/tutti/security/code-scanning/1)

In general, fix this by adding a `permissions:` section that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, all jobs just check out code and run Rust tooling; they do not need write access to the repository, issues, or PRs. The minimal necessary permission is `contents: read` so that `actions/checkout` can fetch the repository.

The single best fix without changing functionality is to add a root-level `permissions:` block (applies to all jobs) right after the `on:` block and before `env:`. This will restrict `GITHUB_TOKEN` for all jobs to read-only repository contents. No additional imports or dependencies are needed, and no job-specific overrides are required since all jobs have the same needs.

Concretely, in `.github/workflows/ci.yml`, between existing lines 8 and 9, insert:

```yaml
permissions:
  contents: read
```

leaving the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance build process security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->