### PR TITLE
feat: include literal command field in tt run --dry-run --json

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -316,6 +316,7 @@ enum DryRunStep {
         agent: Option<String>,
         cwd: String,
         fail_mode: String,
+        command: String,
         summary: String,
     },
     EnsureRunning {
@@ -371,6 +372,7 @@ fn serialize_dry_run(workflow: &ResolvedWorkflow, strict: bool) -> DryRunPlan {
                 agent: agent.clone(),
                 cwd: cwd.display().to_string(),
                 fail_mode: format!("{:?}", fail_mode).to_lowercase(),
+                command: run.clone(),
                 summary: run.clone(),
             }),
             ResolvedStep::EnsureRunning {
@@ -536,11 +538,13 @@ mod tests {
         match &plan.steps[1] {
             DryRunStep::Command {
                 index,
+                command,
                 summary,
                 fail_mode,
                 ..
             } => {
                 assert_eq!(*index, 2);
+                assert_eq!(command, "cargo test");
                 assert_eq!(summary, "cargo test");
                 assert_eq!(fail_mode, "closed");
             }


### PR DESCRIPTION
## Summary
Add a `command` field to dry-run JSON for command-type workflow steps so automation can pre-approve exact commands before execution.

## Changes
- Add `command` to `DryRunStep::Command`
- Populate `command` from resolved `run` string
- Keep existing `summary` for backward compatibility
- Extend unit test assertions for `command`

## Testing
- `cargo test -q serialize_dry_run`

Fixes #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dry-run output to include explicit command information for each step, improving visibility into executed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->