### PR TITLE
fix: coordinate SDLC automation branch with agent worktrees

### DIFF
--- a/docs/CODEX_SDLC_ORCHESTRATION.md
+++ b/docs/CODEX_SDLC_ORCHESTRATION.md
@@ -55,6 +55,8 @@ Use `docs/examples/tutti-codex-sdlc.toml` as a starting point.
 ## Operational notes
 
 - Keep branch naming deterministic: `auto/issue-<num>-<timestamp>`
+- Run branch-creation commands in the implementer `agent_worktree` (not workspace root) to avoid dirtying the wrong checkout
+- Treat `.tutti/state/auto/branch.json` as the source of truth and instruct every SDLC prompting step to commit/push to that branch explicitly
 - Always include issue reference in commit and PR body
 - Enforce docs/version updates in implementation prompt
 - Require test pass before PR open and before merge/land

--- a/docs/examples/tutti-codex-sdlc.toml
+++ b/docs/examples/tutti-codex-sdlc.toml
@@ -67,6 +67,7 @@ fail_mode = "closed"
 id = "create_branch"
 type = "command"
 agent = "implementer"
+cwd = "agent_worktree"
 run = "scripts/automation/create_issue_branch.sh .tutti/state/auto/selected_issue.json .tutti/state/auto/branch.json"
 fail_mode = "closed"
 
@@ -117,6 +118,7 @@ fail_mode = "closed"
 id = "create_branch"
 type = "command"
 agent = "implementer"
+cwd = "agent_worktree"
 run = "scripts/automation/create_issue_branch.sh .tutti/state/auto/selected_issue.json .tutti/state/auto/branch.json"
 fail_mode = "closed"
 
@@ -138,7 +140,7 @@ agent = "implementer"
 inject_files = [".tutti/state/auto/selected_issue.json", ".tutti/state/auto/branch.json"]
 wait_for_idle = true
 wait_timeout_secs = 3600
-text = "Implement the selected issue in src/ using the provided plan and the full issue body from selected_issue.json. Keep scope tight. You must produce concrete code changes that address acceptance criteria, then commit and push. In your final response include changed files, test command(s) run, and the pushed commit SHA. If blocked, state the exact blocker and what missing input is required."
+text = "Implement the selected issue in src/ using the provided plan and the full issue body from selected_issue.json. Use branch.json as source of truth for the target branch and ensure your commits are made on that branch (checkout/switch if needed before committing). Keep scope tight. You must produce concrete code changes that address acceptance criteria, then commit and push that branch. In your final response include changed files, test command(s) run, branch name, and the pushed commit SHA. If blocked, state the exact blocker and what missing input is required."
 
 [[workflow.step]]
 id = "verify_impl_progress"
@@ -153,7 +155,7 @@ agent = "tester"
 inject_files = [".tutti/state/auto/selected_issue.json", ".tutti/state/auto/branch.json"]
 wait_for_idle = true
 wait_timeout_secs = 2400
-text = "Update/add tests for the implemented behavior and run test suite. Fix test failures. Commit test changes and push."
+text = "Update/add tests for the implemented behavior and run test suite. Use branch.json as source of truth for the target branch and commit test changes on that branch (checkout/switch first if needed), then push."
 
 [[workflow.step]]
 id = "docs_and_version"
@@ -162,7 +164,7 @@ agent = "docs-release"
 inject_files = [".tutti/state/auto/selected_issue.json", ".tutti/state/auto/branch.json"]
 wait_for_idle = true
 wait_timeout_secs = 1800
-text = "Update docs and changelog. If behavior changed, increment version in Cargo.toml and note release impact. Commit docs/release changes and push."
+text = "Update docs and changelog. If behavior changed, increment version in Cargo.toml and note release impact. Use branch.json as source of truth for the target branch and commit docs/release changes on that branch (checkout/switch first if needed), then push."
 
 # 5) Hard validation gate
 [[workflow.step]]
@@ -199,7 +201,7 @@ agent = "implementer"
 inject_files = [".tutti/state/auto/coderabbit-feedback.md", ".tutti/state/auto/branch.json"]
 wait_for_idle = true
 wait_timeout_secs = 2400
-text = "Apply CodeRabbit feedback if actionable, rerun tests, and push changes. If no actionable items, state that explicitly."
+text = "Apply CodeRabbit feedback if actionable, rerun tests, and push changes on the branch named in branch.json (checkout/switch first if needed). If no actionable items, state that explicitly."
 
 [[workflow.step]]
 id = "revalidate"

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -3430,6 +3430,98 @@ mod tests {
     }
 
     #[test]
+    fn command_agent_worktree_cwd_resolves_to_agent_worktree_path() {
+        let workflow = WorkflowConfig {
+            name: "verify".to_string(),
+            description: None,
+            schedule: None,
+            steps: vec![WorkflowStepConfig::Command {
+                id: None,
+                depends_on: vec![],
+                run: "git status --short".to_string(),
+                cwd: Some(WorkflowCommandCwd::AgentWorktree),
+                subdir: None,
+                agent: Some("backend".to_string()),
+                timeout_secs: Some(30),
+                fail_mode: Some(WorkflowFailMode::Closed),
+                output_json: None,
+            }],
+        };
+
+        let dir = std::env::temp_dir().join("tutti-test-agent-worktree-cwd");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(".tutti/worktrees/backend")).unwrap();
+
+        let config = sample_config(workflow, vec![]);
+        let opts = ExecuteOptions {
+            strict: false,
+            force_open_commands: false,
+            command_policy: None,
+            retry_policy: None,
+            origin: ExecutionOrigin::Run,
+            hook_event: None,
+            hook_agent: None,
+        };
+
+        let resolved = WorkflowResolver::new(&config, &dir)
+            .resolve("verify", None, &opts)
+            .unwrap();
+        match &resolved.steps[0] {
+            ResolvedStep::Command { cwd, .. } => {
+                assert_eq!(*cwd, dir.join(".tutti/worktrees/backend"));
+            }
+            _ => panic!("expected command step"),
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn command_agent_worktree_cwd_requires_existing_worktree() {
+        let workflow = WorkflowConfig {
+            name: "verify".to_string(),
+            description: None,
+            schedule: None,
+            steps: vec![WorkflowStepConfig::Command {
+                id: None,
+                depends_on: vec![],
+                run: "git status --short".to_string(),
+                cwd: Some(WorkflowCommandCwd::AgentWorktree),
+                subdir: None,
+                agent: Some("backend".to_string()),
+                timeout_secs: Some(30),
+                fail_mode: Some(WorkflowFailMode::Closed),
+                output_json: None,
+            }],
+        };
+
+        let dir = std::env::temp_dir().join("tutti-test-agent-worktree-missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let config = sample_config(workflow, vec![]);
+        let opts = ExecuteOptions {
+            strict: false,
+            force_open_commands: false,
+            command_policy: None,
+            retry_policy: None,
+            origin: ExecutionOrigin::Run,
+            hook_event: None,
+            hook_agent: None,
+        };
+
+        let err = WorkflowResolver::new(&config, &dir)
+            .resolve("verify", None, &opts)
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("agent worktree not found for 'backend'")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn command_policy_block_closed_fails_step() {
         let workflow = WorkflowConfig {
             name: "verify".to_string(),


### PR DESCRIPTION
Closes #38

## Summary
- run SDLC `create_branch` command in implementer `agent_worktree` so branch checkout no longer dirties workspace root
- update SDLC prompts to treat `branch.json` as source of truth and explicitly commit/push to that branch
- add automation resolver tests covering `cwd = "agent_worktree"` happy path and missing-worktree failure
- document the branch/worktree coordination requirement in orchestration docs

## Validation
- cargo fmt --check
- cargo test --quiet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidelines clarifying branch management procedures and source-of-truth handling
  * Enhanced configuration examples with directory execution settings and expanded response requirements

* **Tests**
  * Added tests validating agent worktree path resolution and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->