### PR TITLE
[auto] #16 phase 3: local web dashboard and control-plane history hardening

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -829,12 +829,12 @@ fn events_data(
     let skip_count = parsed.as_ref().map(|c| c.skip_count).unwrap_or(0);
     let mut events = load_events_for_targets(targets, workspace, cursor_ts, false)?;
     // Skip events at the cursor boundary that were already seen
-    if skip_count > 0 {
-        if let Some(ts) = cursor_ts {
-            let boundary_count = events.iter().take_while(|e| e.timestamp == ts).count();
-            if boundary_count > 0 && skip_count <= boundary_count {
-                events = events.into_iter().skip(skip_count).collect();
-            }
+    if skip_count > 0
+        && let Some(ts) = cursor_ts
+    {
+        let boundary_count = events.iter().take_while(|e| e.timestamp == ts).count();
+        if boundary_count > 0 && skip_count <= boundary_count {
+            events = events.into_iter().skip(skip_count).collect();
         }
     }
     Ok(json!(events))


### PR DESCRIPTION
Automated SDLC cycle for #16.

- planner: completed
- implementation: completed
- tests: updated
- docs/changelog: updated
- version: bumped if required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced events cursor to accept either a timestamp or `timestamp|skip_count`, with stricter validation and clear JSON 400 errors for malformed cursors.
  * Event streaming endpoint now rejects cursors containing a non-zero skip count and will not open a stream in that case.

* **Bug Fixes**
  * Improved handling to correctly skip items when a valid skip count aligns with the cursor timestamp boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->