### PR TITLE
fix: satisfy Rust 1.95 clippy lints

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -421,10 +421,7 @@ fn customize_template(
 fn remove_workflow_steps_for_agent(config_body: &mut String, agent_name: &str) {
     // Repeatedly remove [[workflow.step]] blocks containing agent = "agent_name"
     let agent_pattern = format!("agent = \"{}\"", agent_name);
-    loop {
-        let Some(agent_pos) = config_body.find(&agent_pattern) else {
-            break;
-        };
+    while let Some(agent_pos) = config_body.find(&agent_pattern) {
         // Walk backwards to find the [[workflow.step]] header
         let before = &config_body[..agent_pos];
         let Some(block_start) = before.rfind("[[workflow.step]]") else {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1343,7 +1343,7 @@ fn policy_decisions_data(targets: &[WorkspaceTarget], workspace: Option<&str>) -
         let records = state::load_policy_decisions(&target.project_root)?;
         rows.extend(records);
     }
-    rows.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    rows.sort_by_key(|row| std::cmp::Reverse(row.timestamp));
     Ok(json!(rows))
 }
 

--- a/src/cli/switch.rs
+++ b/src/cli/switch.rs
@@ -74,15 +74,15 @@ pub fn run() -> Result<()> {
 
             match key.code {
                 KeyCode::Esc | KeyCode::Char('q') => return Ok(()),
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
-                    if !filtered.is_empty() {
-                        selected = selected.checked_sub(1).unwrap_or(filtered.len() - 1);
-                    }
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K')
+                    if !filtered.is_empty() =>
+                {
+                    selected = selected.checked_sub(1).unwrap_or(filtered.len() - 1);
                 }
-                KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
-                    if !filtered.is_empty() {
-                        selected = (selected + 1) % filtered.len();
-                    }
+                KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J')
+                    if !filtered.is_empty() =>
+                {
+                    selected = (selected + 1) % filtered.len();
                 }
                 KeyCode::Backspace => {
                     query.pop();
@@ -95,10 +95,8 @@ pub fn run() -> Result<()> {
                         attach_result?;
                     }
                 }
-                KeyCode::Char(ch) => {
-                    if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                        query.push(ch);
-                    }
+                KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    query.push(ch);
                 }
                 _ => {}
             }

--- a/src/cli/switch.rs
+++ b/src/cli/switch.rs
@@ -74,14 +74,10 @@ pub fn run() -> Result<()> {
 
             match key.code {
                 KeyCode::Esc | KeyCode::Char('q') => return Ok(()),
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K')
-                    if !filtered.is_empty() =>
-                {
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') if !filtered.is_empty() => {
                     selected = selected.checked_sub(1).unwrap_or(filtered.len() - 1);
                 }
-                KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J')
-                    if !filtered.is_empty() =>
-                {
+                KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') if !filtered.is_empty() => {
                     selected = (selected + 1) % filtered.len();
                 }
                 KeyCode::Backspace => {

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -237,7 +237,7 @@ fn print_workspace_breakdown(workspaces: &[WorkspaceUsage]) {
 
         // Agent sub-rows
         let mut agents: Vec<_> = ws.by_agent.iter().collect();
-        agents.sort_by(|(a, _), (b, _)| a.cmp(b));
+        agents.sort_by_key(|(agent, _)| *agent);
         for (agent_name, agent_usage) in agents {
             table.add_row(vec![
                 format!("  ↳ {agent_name}"),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -925,7 +925,7 @@ pub fn load_active_runs(project_root: &Path) -> Result<Vec<SdlcRunLedgerRecord>>
             records.push(record);
         }
     }
-    records.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    records.sort_by_key(|record| std::cmp::Reverse(record.updated_at));
     Ok(records)
 }
 


### PR DESCRIPTION
## Summary
- update current mainline code for Rust 1.95 clippy lints
- use key-based sorting and simpler control flow where clippy now requires it
- unblock Dependabot PR checks that are failing on repository lints rather than dependency changes

## Verification
- cargo clippy --bin tt -- -D warnings
- cargo test --bin tt artifact
- cargo test --bin tt