### PR TITLE
fix(automation): poll artifact_glob after wait_for_idle settles

### DIFF
--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -1035,6 +1035,7 @@ impl<'a> WorkflowExecutor<'a> {
                         } else {
                             None
                         };
+                        let post_idle_poll_secs = post_idle_artifact_poll_secs(*step_wait_timeout);
 
                         let baseline_pane_hash =
                             TmuxSession::capture_pane(session_name, PROMPT_CAPTURE_LINES)
@@ -1563,23 +1564,25 @@ impl<'a> WorkflowExecutor<'a> {
                                 // Run artifact capture before early success exit
                                 if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                     (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
+                                    && let Ok(artifact_path) = capture_artifact_with_poll(
+                                        pre_snap,
+                                        expanded_pattern,
+                                        art_name,
+                                        post_idle_poll_secs,
+                                        Duration::from_secs(1),
+                                    )
+                                    && let Ok(result) = store_artifact_output(
+                                        self.project_root,
+                                        &run_id,
+                                        art_name,
+                                        &artifact_path,
+                                    )
                                 {
-                                    std::thread::sleep(Duration::from_secs(2));
-                                    if let Ok(artifact_path) =
-                                        capture_artifact(pre_snap, expanded_pattern, art_name)
-                                        && let Ok(result) = store_artifact_output(
-                                            self.project_root,
-                                            &run_id,
-                                            art_name,
-                                            &artifact_path,
-                                        )
-                                    {
-                                        output_files.insert(
-                                            art_name.to_string(),
-                                            result.json_path.display().to_string(),
-                                        );
-                                        outputs.insert(art_name.to_string(), result.value);
-                                    }
+                                    output_files.insert(
+                                        art_name.to_string(),
+                                        result.json_path.display().to_string(),
+                                    );
+                                    outputs.insert(art_name.to_string(), result.value);
                                 }
                                 step_results.push(StepResult {
                                     index: step_index,
@@ -1627,23 +1630,25 @@ impl<'a> WorkflowExecutor<'a> {
                                     // Run artifact capture before early success exit
                                     if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                         (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
+                                        && let Ok(artifact_path) = capture_artifact_with_poll(
+                                            pre_snap,
+                                            expanded_pattern,
+                                            art_name,
+                                            post_idle_poll_secs,
+                                            Duration::from_secs(1),
+                                        )
+                                        && let Ok(result) = store_artifact_output(
+                                            self.project_root,
+                                            &run_id,
+                                            art_name,
+                                            &artifact_path,
+                                        )
                                     {
-                                        std::thread::sleep(Duration::from_secs(2));
-                                        if let Ok(artifact_path) =
-                                            capture_artifact(pre_snap, expanded_pattern, art_name)
-                                            && let Ok(result) = store_artifact_output(
-                                                self.project_root,
-                                                &run_id,
-                                                art_name,
-                                                &artifact_path,
-                                            )
-                                        {
-                                            output_files.insert(
-                                                art_name.to_string(),
-                                                result.json_path.display().to_string(),
-                                            );
-                                            outputs.insert(art_name.to_string(), result.value);
-                                        }
+                                        output_files.insert(
+                                            art_name.to_string(),
+                                            result.json_path.display().to_string(),
+                                        );
+                                        outputs.insert(art_name.to_string(), result.value);
                                     }
                                     step_results.push(StepResult {
                                         index: step_index,
@@ -1721,25 +1726,13 @@ impl<'a> WorkflowExecutor<'a> {
                             // (capped at 60s) so that fast steps stay fast and slow flushes
                             // don't false-fail.
                             // See https://github.com/nutthouse/tutti/issues/120
-                            let post_idle_poll_secs = std::cmp::min(
-                                std::cmp::max(*step_wait_timeout / 30, 5),
-                                60,
+                            let capture_result = capture_artifact_with_poll(
+                                pre_snap,
+                                expanded_pattern,
+                                art_name,
+                                post_idle_poll_secs,
+                                Duration::from_secs(1),
                             );
-                            let poll_interval = Duration::from_secs(1);
-                            let poll_deadline = Duration::from_secs(post_idle_poll_secs);
-                            let poll_start = std::time::Instant::now();
-
-                            let capture_result = loop {
-                                match capture_artifact(pre_snap, expanded_pattern, art_name) {
-                                    Ok(p) => break Ok(p),
-                                    Err(e) => {
-                                        if poll_start.elapsed() >= poll_deadline {
-                                            break Err(e);
-                                        }
-                                        std::thread::sleep(poll_interval);
-                                    }
-                                }
-                            };
 
                             match capture_result {
                                 Ok(artifact_path) => {
@@ -2801,6 +2794,33 @@ fn snapshot_artifact_glob(pattern: &str) -> Result<HashSet<PathBuf>> {
         TuttiError::ConfigValidation(format!("invalid artifact_glob pattern '{}': {e}", pattern))
     })?;
     Ok(paths.filter_map(|p| p.ok()).collect())
+}
+
+fn post_idle_artifact_poll_secs(wait_timeout_secs: u64) -> u64 {
+    (wait_timeout_secs / 30).clamp(5, 60)
+}
+
+fn capture_artifact_with_poll(
+    pre_snapshot: &HashSet<PathBuf>,
+    pattern: &str,
+    artifact_name: &str,
+    poll_secs: u64,
+    poll_interval: Duration,
+) -> Result<PathBuf> {
+    let poll_deadline = Duration::from_secs(poll_secs);
+    let poll_start = std::time::Instant::now();
+
+    loop {
+        match capture_artifact(pre_snapshot, pattern, artifact_name) {
+            Ok(path) => break Ok(path),
+            Err(err) => {
+                if poll_start.elapsed() >= poll_deadline {
+                    break Err(err);
+                }
+                std::thread::sleep(poll_interval);
+            }
+        }
+    }
 }
 
 /// After a step completes, capture the newest artifact that appeared since the pre-step snapshot.
@@ -6339,6 +6359,43 @@ mod tests {
         assert!(err.to_string().contains("matched no new files"));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn capture_artifact_with_poll_waits_for_late_file() {
+        let dir = std::env::temp_dir().join("tutti-test-capture-poll");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let pattern = format!("{}/*.md", dir.display());
+        let pre_snapshot = snapshot_artifact_glob(&pattern).unwrap();
+        let late_file = dir.join("design-late.md");
+        let writer_path = late_file.clone();
+
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            std::fs::write(&writer_path, "late artifact").unwrap();
+        });
+
+        let result = capture_artifact_with_poll(
+            &pre_snapshot,
+            &pattern,
+            "design_doc",
+            1,
+            std::time::Duration::from_millis(5),
+        )
+        .unwrap();
+        writer.join().unwrap();
+        assert_eq!(result, late_file);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn post_idle_artifact_poll_secs_is_bounded() {
+        assert_eq!(post_idle_artifact_poll_secs(30), 5);
+        assert_eq!(post_idle_artifact_poll_secs(1800), 60);
+        assert_eq!(post_idle_artifact_poll_secs(3600), 60);
     }
 
     #[test]

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -2899,7 +2899,10 @@ fn capture_artifact_with_poll(
             Ok(path) => break Ok(path),
             Err(err) => {
                 if poll_start.elapsed() >= poll_deadline {
-                    break Err(err);
+                    break Err(TuttiError::ConfigValidation(format!(
+                        "artifact '{}' did not appear within {}s after completion; verify artifact_glob '{}' or increase wait_timeout_secs. Last capture error: {err}",
+                        artifact_name, poll_secs, pattern
+                    )));
                 }
                 std::thread::sleep(poll_interval);
             }
@@ -6471,6 +6474,33 @@ mod tests {
         .unwrap();
         writer.join().unwrap();
         assert_eq!(result, late_file);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn capture_artifact_with_poll_timeout_is_actionable() {
+        let dir = std::env::temp_dir().join("tutti-test-capture-poll-timeout");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let pattern = format!("{}/*.md", dir.display());
+        let pre_snapshot = snapshot_artifact_glob(&pattern).unwrap();
+
+        let err = capture_artifact_with_poll(
+            &pre_snapshot,
+            &pattern,
+            "design_doc",
+            0,
+            std::time::Duration::from_millis(1),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("did not appear within 0s after completion"));
+        assert!(err.contains("verify artifact_glob"));
+        assert!(err.contains("increase wait_timeout_secs"));
+        assert!(err.contains("matched no new files"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -1331,6 +1331,48 @@ impl<'a> WorkflowExecutor<'a> {
                                             }
                                         }
 
+                                        if let (
+                                            Some((expanded_pattern, pre_snap)),
+                                            Some(art_name),
+                                        ) = (
+                                            artifact_pre_snapshot.as_ref(),
+                                            artifact_name.as_deref(),
+                                        ) {
+                                            let result = match capture_and_store_artifact_output(
+                                                self.project_root,
+                                                &run_id,
+                                                expanded_pattern,
+                                                pre_snap,
+                                                art_name,
+                                                post_idle_poll_secs,
+                                            ) {
+                                                Ok(result) => result,
+                                                Err(e) => {
+                                                    failed_steps.push(step_index);
+                                                    success = false;
+                                                    step_results.push(StepResult {
+                                                        index: step_index,
+                                                        step_type: "prompt".to_string(),
+                                                        status: StepStatus::Failed,
+                                                        duration_ms: started.elapsed().as_millis()
+                                                            as u64,
+                                                        exit_code: None,
+                                                        timed_out: false,
+                                                        message: Some(e.to_string()),
+                                                        stdout: None,
+                                                        stderr: None,
+                                                    });
+                                                    break;
+                                                }
+                                            };
+
+                                            output_files.insert(
+                                                art_name.to_string(),
+                                                result.json_path.display().to_string(),
+                                            );
+                                            outputs.insert(art_name.to_string(), result.value);
+                                        }
+
                                         step_results.push(StepResult {
                                             index: step_index,
                                             step_type: "prompt".to_string(),
@@ -1478,77 +1520,79 @@ impl<'a> WorkflowExecutor<'a> {
                                             agent,
                                         )?
                                     {
-                                        continue;
-                                    }
-                                    let retry_prompt = "Your previous attempt produced no commit beyond the branch baseline in .tutti/state/auto/branch.json. You are not done yet. If your worktree already has local code changes, do not keep exploring the repo. Review only the existing diff, keep the smallest valid slice, then stage it, commit it, and push it to the target branch now. If there are no useful local changes yet, make the smallest coherent code change now, commit it, and push it. If no valid code change is possible, reply with 'BLOCKED:' and the exact reason.";
-                                    if !TmuxSession::session_exists(session_name) {
-                                        start_and_wait_ready(
-                                            self.project_root,
-                                            self.config,
-                                            agent,
+                                        // Fall through to the shared post-step artifact capture
+                                        // and success recording below.
+                                    } else {
+                                        let retry_prompt = "Your previous attempt produced no commit beyond the branch baseline in .tutti/state/auto/branch.json. You are not done yet. If your worktree already has local code changes, do not keep exploring the repo. Review only the existing diff, keep the smallest valid slice, then stage it, commit it, and push it to the target branch now. If there are no useful local changes yet, make the smallest coherent code change now, commit it, and push it. If no valid code change is possible, reply with 'BLOCKED:' and the exact reason.";
+                                        if !TmuxSession::session_exists(session_name) {
+                                            start_and_wait_ready(
+                                                self.project_root,
+                                                self.config,
+                                                agent,
+                                                session_name,
+                                            )?;
+                                        }
+                                        TmuxSession::send_text(session_name, retry_prompt)?;
+                                        maybe_submit_buffered_prompt(session_name, retry_prompt)?;
+
+                                        if !wait_for_prompt_activity_or_output(
+                                            runtime,
                                             session_name,
+                                            retry_prompt,
+                                            None,
+                                            output_json.as_deref(),
+                                            Duration::from_secs(60),
+                                        )? {
+                                            failed_steps.push(step_index);
+                                            success = false;
+                                            step_results.push(StepResult {
+                                                index: step_index,
+                                                step_type: "prompt".to_string(),
+                                                status: StepStatus::Failed,
+                                                duration_ms: started.elapsed().as_millis() as u64,
+                                                exit_code: None,
+                                                timed_out: true,
+                                                message: Some(
+                                                    "implement_code retry did not start activity or produce output within 60s"
+                                                        .to_string(),
+                                                ),
+                                                stdout: None,
+                                                stderr: None,
+                                            });
+                                            break;
+                                        }
+
+                                        let retry_wait = health::wait_for_agent_idle(
+                                            runtime,
+                                            session_name,
+                                            Duration::from_secs((*wait_timeout_secs).max(1)),
+                                            Duration::from_secs(5),
+                                            Duration::from_secs(10),
                                         )?;
-                                    }
-                                    TmuxSession::send_text(session_name, retry_prompt)?;
-                                    maybe_submit_buffered_prompt(session_name, retry_prompt)?;
-
-                                    if !wait_for_prompt_activity_or_output(
-                                        runtime,
-                                        session_name,
-                                        retry_prompt,
-                                        None,
-                                        output_json.as_deref(),
-                                        Duration::from_secs(60),
-                                    )? {
-                                        failed_steps.push(step_index);
-                                        success = false;
-                                        step_results.push(StepResult {
-                                            index: step_index,
-                                            step_type: "prompt".to_string(),
-                                            status: StepStatus::Failed,
-                                            duration_ms: started.elapsed().as_millis() as u64,
-                                            exit_code: None,
-                                            timed_out: true,
-                                            message: Some(
-                                                "implement_code retry did not start activity or produce output within 60s"
-                                                    .to_string(),
-                                            ),
-                                            stdout: None,
-                                            stderr: None,
-                                        });
-                                        break;
-                                    }
-
-                                    let retry_wait = health::wait_for_agent_idle(
-                                        runtime,
-                                        session_name,
-                                        Duration::from_secs((*wait_timeout_secs).max(1)),
-                                        Duration::from_secs(5),
-                                        Duration::from_secs(10),
-                                    )?;
-                                    if !retry_wait.is_completed()
-                                        || !prompt_step_has_branch_progress(
-                                            self.project_root,
-                                            agent,
-                                        )?
-                                    {
-                                        failed_steps.push(step_index);
-                                        success = false;
-                                        step_results.push(StepResult {
-                                            index: step_index,
-                                            step_type: "prompt".to_string(),
-                                            status: StepStatus::Failed,
-                                            duration_ms: started.elapsed().as_millis() as u64,
-                                            exit_code: None,
-                                            timed_out: false,
-                                            message: Some(
-                                                "implement_code completed without a commit beyond the branch baseline"
-                                                    .to_string(),
-                                            ),
-                                            stdout: None,
-                                            stderr: None,
-                                        });
-                                        break;
+                                        if !retry_wait.is_completed()
+                                            || !prompt_step_has_branch_progress(
+                                                self.project_root,
+                                                agent,
+                                            )?
+                                        {
+                                            failed_steps.push(step_index);
+                                            success = false;
+                                            step_results.push(StepResult {
+                                                index: step_index,
+                                                step_type: "prompt".to_string(),
+                                                status: StepStatus::Failed,
+                                                duration_ms: started.elapsed().as_millis() as u64,
+                                                exit_code: None,
+                                                timed_out: false,
+                                                message: Some(
+                                                    "implement_code completed without a commit beyond the branch baseline"
+                                                        .to_string(),
+                                                ),
+                                                stdout: None,
+                                                stderr: None,
+                                            });
+                                            break;
+                                        }
                                     }
                                 }
                             }
@@ -1565,37 +1609,13 @@ impl<'a> WorkflowExecutor<'a> {
                                 if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                     (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
                                 {
-                                    let artifact_path = match capture_artifact_with_poll(
-                                        pre_snap,
-                                        expanded_pattern,
-                                        art_name,
-                                        post_idle_poll_secs,
-                                        Duration::from_secs(1),
-                                    ) {
-                                        Ok(path) => path,
-                                        Err(e) => {
-                                            failed_steps.push(step_index);
-                                            success = false;
-                                            step_results.push(StepResult {
-                                                index: step_index,
-                                                step_type: "prompt".to_string(),
-                                                status: StepStatus::Failed,
-                                                duration_ms: started.elapsed().as_millis() as u64,
-                                                exit_code: None,
-                                                timed_out: false,
-                                                message: Some(e.to_string()),
-                                                stdout: None,
-                                                stderr: None,
-                                            });
-                                            break;
-                                        }
-                                    };
-
-                                    let result = match store_artifact_output(
+                                    let result = match capture_and_store_artifact_output(
                                         self.project_root,
                                         &run_id,
+                                        expanded_pattern,
+                                        pre_snap,
                                         art_name,
-                                        &artifact_path,
+                                        post_idle_poll_secs,
                                     ) {
                                         Ok(result) => result,
                                         Err(e) => {
@@ -1608,10 +1628,7 @@ impl<'a> WorkflowExecutor<'a> {
                                                 duration_ms: started.elapsed().as_millis() as u64,
                                                 exit_code: None,
                                                 timed_out: false,
-                                                message: Some(format!(
-                                                    "artifact capture failed for '{}': {e}",
-                                                    art_name
-                                                )),
+                                                message: Some(e.to_string()),
                                                 stdout: None,
                                                 stderr: None,
                                             });
@@ -1672,38 +1689,13 @@ impl<'a> WorkflowExecutor<'a> {
                                     if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                         (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
                                     {
-                                        let artifact_path = match capture_artifact_with_poll(
-                                            pre_snap,
-                                            expanded_pattern,
-                                            art_name,
-                                            post_idle_poll_secs,
-                                            Duration::from_secs(1),
-                                        ) {
-                                            Ok(path) => path,
-                                            Err(e) => {
-                                                failed_steps.push(step_index);
-                                                success = false;
-                                                step_results.push(StepResult {
-                                                    index: step_index,
-                                                    step_type: "prompt".to_string(),
-                                                    status: StepStatus::Failed,
-                                                    duration_ms: started.elapsed().as_millis()
-                                                        as u64,
-                                                    exit_code: None,
-                                                    timed_out: false,
-                                                    message: Some(e.to_string()),
-                                                    stdout: None,
-                                                    stderr: None,
-                                                });
-                                                break;
-                                            }
-                                        };
-
-                                        let result = match store_artifact_output(
+                                        let result = match capture_and_store_artifact_output(
                                             self.project_root,
                                             &run_id,
+                                            expanded_pattern,
+                                            pre_snap,
                                             art_name,
-                                            &artifact_path,
+                                            post_idle_poll_secs,
                                         ) {
                                             Ok(result) => result,
                                             Err(e) => {
@@ -1717,10 +1709,7 @@ impl<'a> WorkflowExecutor<'a> {
                                                         as u64,
                                                     exit_code: None,
                                                     timed_out: false,
-                                                    message: Some(format!(
-                                                        "artifact capture failed for '{}': {e}",
-                                                        art_name
-                                                    )),
+                                                    message: Some(e.to_string()),
                                                     stdout: None,
                                                     stderr: None,
                                                 });
@@ -1810,49 +1799,22 @@ impl<'a> WorkflowExecutor<'a> {
                             // (capped at 60s) so that fast steps stay fast and slow flushes
                             // don't false-fail.
                             // See https://github.com/nutthouse/tutti/issues/120
-                            let capture_result = capture_artifact_with_poll(
-                                pre_snap,
+                            let capture_result = capture_and_store_artifact_output(
+                                self.project_root,
+                                &run_id,
                                 expanded_pattern,
+                                pre_snap,
                                 art_name,
                                 post_idle_poll_secs,
-                                Duration::from_secs(1),
                             );
 
                             match capture_result {
-                                Ok(artifact_path) => {
-                                    match store_artifact_output(
-                                        self.project_root,
-                                        &run_id,
-                                        art_name,
-                                        &artifact_path,
-                                    ) {
-                                        Ok(result) => {
-                                            output_files.insert(
-                                                art_name.to_string(),
-                                                result.json_path.display().to_string(),
-                                            );
-                                            outputs.insert(art_name.to_string(), result.value);
-                                        }
-                                        Err(e) => {
-                                            failed_steps.push(step_index);
-                                            success = false;
-                                            step_results.push(StepResult {
-                                                index: step_index,
-                                                step_type: "prompt".to_string(),
-                                                status: StepStatus::Failed,
-                                                duration_ms: started.elapsed().as_millis() as u64,
-                                                exit_code: None,
-                                                timed_out: false,
-                                                message: Some(format!(
-                                                    "artifact capture failed for '{}': {e}",
-                                                    art_name
-                                                )),
-                                                stdout: None,
-                                                stderr: None,
-                                            });
-                                            break;
-                                        }
-                                    }
+                                Ok(result) => {
+                                    output_files.insert(
+                                        art_name.to_string(),
+                                        result.json_path.display().to_string(),
+                                    );
+                                    outputs.insert(art_name.to_string(), result.value);
                                 }
                                 Err(e) => {
                                     failed_steps.push(step_index);
@@ -2908,6 +2870,30 @@ fn capture_artifact_with_poll(
             }
         }
     }
+}
+
+fn capture_and_store_artifact_output(
+    project_root: &Path,
+    run_id: &str,
+    expanded_pattern: &str,
+    pre_snapshot: &HashSet<PathBuf>,
+    artifact_name: &str,
+    poll_secs: u64,
+) -> Result<ArtifactStoreResult> {
+    let artifact_path = capture_artifact_with_poll(
+        pre_snapshot,
+        expanded_pattern,
+        artifact_name,
+        poll_secs,
+        Duration::from_secs(1),
+    )?;
+
+    store_artifact_output(project_root, run_id, artifact_name, &artifact_path).map_err(|e| {
+        TuttiError::ConfigValidation(format!(
+            "artifact capture failed for '{}': {e}",
+            artifact_name
+        ))
+    })
 }
 
 /// After a step completes, capture the newest artifact that appeared since the pre-step snapshot.

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -1564,20 +1564,61 @@ impl<'a> WorkflowExecutor<'a> {
                                 // Run artifact capture before early success exit
                                 if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                     (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
-                                    && let Ok(artifact_path) = capture_artifact_with_poll(
+                                {
+                                    let artifact_path = match capture_artifact_with_poll(
                                         pre_snap,
                                         expanded_pattern,
                                         art_name,
                                         post_idle_poll_secs,
                                         Duration::from_secs(1),
-                                    )
-                                    && let Ok(result) = store_artifact_output(
+                                    ) {
+                                        Ok(path) => path,
+                                        Err(e) => {
+                                            failed_steps.push(step_index);
+                                            success = false;
+                                            step_results.push(StepResult {
+                                                index: step_index,
+                                                step_type: "prompt".to_string(),
+                                                status: StepStatus::Failed,
+                                                duration_ms: started.elapsed().as_millis() as u64,
+                                                exit_code: None,
+                                                timed_out: false,
+                                                message: Some(e.to_string()),
+                                                stdout: None,
+                                                stderr: None,
+                                            });
+                                            break;
+                                        }
+                                    };
+
+                                    let result = match store_artifact_output(
                                         self.project_root,
                                         &run_id,
                                         art_name,
                                         &artifact_path,
-                                    )
-                                {
+                                    ) {
+                                        Ok(result) => result,
+                                        Err(e) => {
+                                            failed_steps.push(step_index);
+                                            success = false;
+                                            step_results.push(StepResult {
+                                                index: step_index,
+                                                step_type: "prompt".to_string(),
+                                                status: StepStatus::Failed,
+                                                duration_ms: started.elapsed().as_millis() as u64,
+                                                exit_code: None,
+                                                timed_out: false,
+                                                message: Some(format!(
+                                                    "artifact capture failed for '{}': {e}",
+                                                    art_name
+                                                )),
+                                                stdout: None,
+                                                stderr: None,
+                                            });
+                                            break;
+                                        }
+                                    };
+
                                     output_files.insert(
                                         art_name.to_string(),
                                         result.json_path.display().to_string(),
@@ -1630,20 +1671,63 @@ impl<'a> WorkflowExecutor<'a> {
                                     // Run artifact capture before early success exit
                                     if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                                         (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
-                                        && let Ok(artifact_path) = capture_artifact_with_poll(
+                                    {
+                                        let artifact_path = match capture_artifact_with_poll(
                                             pre_snap,
                                             expanded_pattern,
                                             art_name,
                                             post_idle_poll_secs,
                                             Duration::from_secs(1),
-                                        )
-                                        && let Ok(result) = store_artifact_output(
+                                        ) {
+                                            Ok(path) => path,
+                                            Err(e) => {
+                                                failed_steps.push(step_index);
+                                                success = false;
+                                                step_results.push(StepResult {
+                                                    index: step_index,
+                                                    step_type: "prompt".to_string(),
+                                                    status: StepStatus::Failed,
+                                                    duration_ms: started.elapsed().as_millis()
+                                                        as u64,
+                                                    exit_code: None,
+                                                    timed_out: false,
+                                                    message: Some(e.to_string()),
+                                                    stdout: None,
+                                                    stderr: None,
+                                                });
+                                                break;
+                                            }
+                                        };
+
+                                        let result = match store_artifact_output(
                                             self.project_root,
                                             &run_id,
                                             art_name,
                                             &artifact_path,
-                                        )
-                                    {
+                                        ) {
+                                            Ok(result) => result,
+                                            Err(e) => {
+                                                failed_steps.push(step_index);
+                                                success = false;
+                                                step_results.push(StepResult {
+                                                    index: step_index,
+                                                    step_type: "prompt".to_string(),
+                                                    status: StepStatus::Failed,
+                                                    duration_ms: started.elapsed().as_millis()
+                                                        as u64,
+                                                    exit_code: None,
+                                                    timed_out: false,
+                                                    message: Some(format!(
+                                                        "artifact capture failed for '{}': {e}",
+                                                        art_name
+                                                    )),
+                                                    stdout: None,
+                                                    stderr: None,
+                                                });
+                                                break;
+                                            }
+                                        };
+
                                         output_files.insert(
                                             art_name.to_string(),
                                             result.json_path.display().to_string(),

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -1714,10 +1714,34 @@ impl<'a> WorkflowExecutor<'a> {
                         if let (Some((expanded_pattern, pre_snap)), Some(art_name)) =
                             (artifact_pre_snapshot.as_ref(), artifact_name.as_deref())
                         {
-                            // Brief settle time for filesystem I/O
-                            std::thread::sleep(Duration::from_secs(2));
+                            // Poll for the artifact to materialize. wait_for_agent_idle
+                            // can return as soon as the runtime emits a completion signal,
+                            // which may be before the agent's file write is flushed to disk.
+                            // Use a short bounded poll window proportional to wait_timeout_secs
+                            // (capped at 60s) so that fast steps stay fast and slow flushes
+                            // don't false-fail.
+                            // See https://github.com/nutthouse/tutti/issues/120
+                            let post_idle_poll_secs = std::cmp::min(
+                                std::cmp::max(*step_wait_timeout / 30, 5),
+                                60,
+                            );
+                            let poll_interval = Duration::from_secs(1);
+                            let poll_deadline = Duration::from_secs(post_idle_poll_secs);
+                            let poll_start = std::time::Instant::now();
 
-                            match capture_artifact(pre_snap, expanded_pattern, art_name) {
+                            let capture_result = loop {
+                                match capture_artifact(pre_snap, expanded_pattern, art_name) {
+                                    Ok(p) => break Ok(p),
+                                    Err(e) => {
+                                        if poll_start.elapsed() >= poll_deadline {
+                                            break Err(e);
+                                        }
+                                        std::thread::sleep(poll_interval);
+                                    }
+                                }
+                            };
+
+                            match capture_result {
                                 Ok(artifact_path) => {
                                     match store_artifact_output(
                                         self.project_root,


### PR DESCRIPTION
Supersedes #121 from Brian's fork so the required repository CI can attach normally after the branch protection updates. This preserves Brian's original fix plus the two CodeRabbit-requested follow-ups that were already reviewed on #121.

Fixes #120.

## Versioning
- SemVer: PATCH
- Version bump: none in this PR; queued for the normal release flow.
- Release tag: none.

## Validation
- cargo fmt --all -- --check
- cargo check
- cargo test --bin tt artifact
- HOME=/private/tmp/tutti-test-home CARGO_HOME=/Users/adamnutt/.cargo cargo test --bin tt -- --test-threads=1