### PR TITLE
fix: keep release notes out of package tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,12 +83,12 @@ jobs:
             }
             capture { print }
             END { if (!found) exit 1 }
-          ' CHANGELOG.md > release-notes.md || {
+          ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md" || {
             {
               echo "## Tutti v$version"
               echo
               echo "See CHANGELOG.md for release details."
-            } > release-notes.md
+            } > "$RUNNER_TEMP/release-notes.md"
           }
 
       - name: Format
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: release-notes
-          path: release-notes.md
+          path: ${{ runner.temp }}/release-notes.md
 
   build:
     name: Build ${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Fixes the v0.10.1 Release workflow failure in cargo package --locked.
- Writes generated release notes to runner temp instead of the checkout so Cargo sees a clean package tree.

## Validation
- release.yml parsed as YAML locally
- release note extraction writes to runner temp locally
- cargo package --locked --allow-dirty --no-verify packaged successfully from the hotfix branch

## Release impact
After merge, move tag v0.10.1 to the new main commit and push it to rerun the Release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release notes generation and artifact upload reliability in the release workflow with a fallback mechanism for extraction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->